### PR TITLE
Start of the data packet code

### DIFF
--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -221,6 +221,9 @@ static clib_error_t * ipfix_init (vlib_main_t * vm)
   /* Initialize expired flow records vector */
   sm->expired_records = 0;
 
+  /* Initialize IPFIX data packets vector */
+  sm->data_packets = 0;
+
   clib_bihash_init_48_8(&sm->flow_hash, "flowhash", 1048, 128<<20);
 
   error = ipfix_plugin_api_hookup (vm);

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -23,6 +23,7 @@
 #include <vppinfra/error.h>
 #include <vppinfra/elog.h>
 #include <vppinfra/vec.h>
+#include <ipfix/netflow_v10.h>
 
 typedef struct {
   ip4_address_t src;
@@ -51,6 +52,9 @@ typedef struct {
 
   /* vector of expired flows to export */
   ipfix_ip4_flow_value_t * expired_records;
+
+  /* vector of IPFIX data packets to be transmitted */
+  netflow_v10_data_packet_t *data_packets;
 
   /* convenience */
   vnet_main_t * vnet_main;

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -41,19 +41,19 @@ typedef struct {
 } ipfix_ip4_flow_value_t;
 
 typedef struct {
-    /* API message ID base */
-    u16 msg_id_base;
+  /* API message ID base */
+  u16 msg_id_base;
 
-    clib_bihash_48_8_t flow_hash;
+  clib_bihash_48_8_t flow_hash;
 
-    /* vector of flow records */
-    ipfix_ip4_flow_value_t * flow_records;
+  /* vector of flow records */
+  ipfix_ip4_flow_value_t * flow_records;
 
   /* vector of expired flows to export */
   ipfix_ip4_flow_value_t * expired_records;
 
-    /* convenience */
-    vnet_main_t * vnet_main;
+  /* convenience */
+  vnet_main_t * vnet_main;
 } ipfix_main_t;
 
 extern ipfix_main_t ipfix_main;

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -1,0 +1,51 @@
+#include <vnet/vnet.h>
+
+// IPFIX fields. TODO: Parse from CSV file.
+#define protocolIdentifier 4
+#define sourceTransportPort 7
+#define sourceIPv4Address 8
+#define destinationTransportPort 11
+#define destinationIPv4Address 12
+#define flowStartMilliseconds 152
+#define flowEndMilliseconds 153
+
+typedef struct {
+  u16 version;
+  u16 byte_length;
+  u32 timestamp;
+  u32 sequence_number;
+  u32 observation_domain;
+} netflow_v10_header_t;
+
+/* Structures for templates */
+typedef struct {
+  u16 identifier;
+  u16 size; // In octets.
+  u32 enterprise_number;
+} netflow_v10_field_specifier_t;
+
+typedef struct {
+  u16 id;
+
+  /* Vector of fields */
+  netflow_v10_field_specifier_t *fields;
+} netflow_v10_template_set_t;
+
+typedef struct {
+  /* Vector of sets. */
+  netflow_v10_template_set_t *sets;
+} netflow_v10_template_t;
+/* Structures for data packets */
+
+typedef struct {
+  u8 *data; // Pointer to some data with the packet data.
+} netflow_v10_data_record_t;
+
+typedef struct {
+  netflow_v10_data_record_t *fields;
+} netflow_v10_data_record_set_t;
+
+typedef struct {
+  netflow_v10_header_t header;
+  netflow_v10_data_record_set_t *sets;
+} netflow_v10_data_packet_t;

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -28,6 +28,16 @@ typedef struct {
 
 typedef struct {
   u16 id;
+  u16 length;
+} netflow_v10_set_header_t;
+
+typedef struct {
+  netflow_v10_set_header_t header;
+  u8 *data;
+} netflow_v10_data_set_t;
+
+typedef struct {
+  u16 id;
 
   /* Vector of fields */
   netflow_v10_field_specifier_t *fields;
@@ -44,11 +54,6 @@ typedef struct {
 } netflow_v10_data_record_t;
 
 typedef struct {
-  u16 id;
-  netflow_v10_data_record_t *fields;
-} netflow_v10_data_record_set_t;
-
-typedef struct {
   netflow_v10_header_t header;
-  netflow_v10_data_record_set_t *sets;
+  netflow_v10_data_set_t *sets;
 } netflow_v10_data_packet_t;

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -42,6 +42,7 @@ typedef struct {
 } netflow_v10_data_record_t;
 
 typedef struct {
+  u16 id;
   netflow_v10_data_record_t *fields;
 } netflow_v10_data_record_set_t;
 

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -24,6 +24,7 @@ typedef struct {
   u16 identifier;
   u16 size; // In octets.
   u32 enterprise_number;
+  size_t record_offset;
 } netflow_v10_field_specifier_t;
 
 typedef struct {

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -1,6 +1,8 @@
 #include <vnet/vnet.h>
 
 // IPFIX fields. TODO: Parse from CSV file.
+#define octetDeltaCount 1
+#define packetDeltaCount 2
 #define protocolIdentifier 4
 #define sourceTransportPort 7
 #define sourceIPv4Address 8

--- a/ipfix/node.c
+++ b/ipfix/node.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2017 Igalia
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -550,12 +551,8 @@ static void ipfix_build_v10_packet(ipfix_ip4_flow_value_t *record,
     netflow_v10_data_set_t active_set;
     active_set.data = malloc(data_size);
     void *ptr = (size_t)active_set.data;
-    void *record_ptr;
     vec_foreach(field, set->fields) {
-      record_ptr = (size_t)&record + field->record_offset;
-      clib_warning("Writing to address: %d (record: %d)\n", record_ptr, &record);
-      clib_warning("Data: %U\n", format_ip4_address, record_ptr);
-      memcpy(ptr, record_ptr, field->size);
+      memcpy(ptr, (void *)((size_t)record + field->record_offset), field->size);
 
       // Advance the pointer to the next field.
       ptr = (void *)((size_t)ptr + field->size);


### PR DESCRIPTION
The code is Netflow V10 only so far.

The code currently iterates over each expired flow and produces a data packet based on a basic template, build up so that the data packet knows what to generate. The template should be replaced further down the line. The data packet is a header and then a vector of sets, each set consists of a set header as defined in [RFC 3011 §3.3.2](https://tools.ietf.org/html/rfc7011#section-3.3.2) and chunk of data allocated on the heap of all the fields. The fields should be accessed using the set offsets provided in the `size` field of the template set struct.

There is a basic function which iterates over the struct, calculates the size of the set data + set header and memcpy's it onto the `vlib_buffer_t` passed to the function.

Things missing from this PR are:

- V9 support
- Flexible templates (it's a static template including all the recorded information)
- Testing around the writing of the data packets

Currently the plugin assumes there is enough size to fit the whole packet, if you give it a buffer that's smaller than the packets contents, it'll just write past the allocated amount, most likely segfaulting. This probably wants fixing, maybe we could pass the size in and validate the data packet fits in said size.