### PR TITLE
Send IPFIX packets via UDP

### DIFF
--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -28,6 +28,16 @@ typedef struct {
 
 typedef struct {
   u16 id;
+  u16 length;
+} netflow_v10_set_header_t;
+
+typedef struct {
+  netflow_v10_set_header_t header;
+  u8 *data;
+} netflow_v10_data_set_t;
+
+typedef struct {
+  u16 id;
 
   /* Vector of fields */
   netflow_v10_field_specifier_t *fields;
@@ -44,11 +54,6 @@ typedef struct {
 } netflow_v10_data_record_t;
 
 typedef struct {
-  u16 id;
-  netflow_v10_data_record_t *fields;
-} netflow_v10_data_record_set_t;
-
-typedef struct {
   netflow_v10_header_t header;
-  netflow_v10_data_record_set_t *sets;
+  netflow_v10_data_set_t *sets;
 } netflow_v10_data_packet_t;

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -1,6 +1,8 @@
 #include <vnet/vnet.h>
 
 // IPFIX fields. TODO: Parse from CSV file.
+#define octetDeltaCount 1
+#define packetDeltaCount 2
 #define protocolIdentifier 4
 #define sourceTransportPort 7
 #define sourceIPv4Address 8

--- a/ipfix/node.c
+++ b/ipfix/node.c
@@ -619,17 +619,22 @@ static u64 ipfix_write_v10_data_packet(void *buffer, netflow_v10_data_packet_t *
     data_set = vec_elt_at_index(packet->sets, set_idx);
 
     // Calculate the length of the set.
-    size_t set_length = sizeof(netflow_v10_set_header_t);
+    size_t header_length = sizeof(netflow_v10_set_header_t);
+    size_t data_length = 0;
     vec_foreach(field_spec, template_set->fields) {
-      set_length = set_length + field_spec->size;
+      data_length = data_length + field_spec->size;
     };
 
     // Should be able to just memcopy the entire set, data 'n all.
-    memcpy(ptr, data_set, set_length);
-    written = written + (u64)set_length;
+    data_set->header.id = htons(1);
+    data_set->header.length = htons(data_length);
+    memcpy(ptr, &data_set->header, header_length);
+    ptr = (void*)((size_t)ptr + header_length);
+    memcpy(ptr, data_set->data, data_length);
+    written = written + (u64)header_length + (u64)data_length;
 
     // Advence the pointer past the set.
-    ptr = (void *)((size_t)ptr + set_length);
+    ptr = (void *)((size_t)ptr + header_length + data_length);
   };
 
   return written;

--- a/ipfix/node.c
+++ b/ipfix/node.c
@@ -514,6 +514,7 @@ static void ipfix_free_v10_packet(netflow_v10_data_packet_t *packet)
 static void ipfix_build_v10_packet(ipfix_ip4_flow_value_t *record,
                                    netflow_v10_data_packet_t *packet)
 {
+  u64 byte_length = 16;
   netflow_v10_template_t template;
   ipfix_make_v10_template(&template);
 
@@ -526,6 +527,7 @@ static void ipfix_build_v10_packet(ipfix_ip4_flow_value_t *record,
   packet->sets = 0;
   packet->header.version = ntohs(10);
   packet->header.timestamp = ntohs(current_time_clock.tv_sec);
+  /* set length field in header at end */
 
   netflow_v10_template_set_t *set;
   netflow_v10_field_specifier_t *field;
@@ -534,6 +536,7 @@ static void ipfix_build_v10_packet(ipfix_ip4_flow_value_t *record,
     vec_foreach(field, set->fields) {
       data_size = data_size + field->size;
     }
+    byte_length += data_size;
 
     netflow_v10_data_set_t active_set;
     active_set.data = malloc(data_size);
@@ -584,6 +587,8 @@ static void ipfix_build_v10_packet(ipfix_ip4_flow_value_t *record,
       // Advance the pointer to the next field.
       ptr = (void *)((size_t)ptr + field->size);
     };
+
+    packet->header.byte_length = ntohs(byte_length);
 
     vec_add1(packet->sets, active_set);
   };


### PR DESCRIPTION
This builds on PR #2 and adds in support for sending the built up flow records. It's not quite correct yet because some fields in the packet payload need to be filled in (like the `byte_length` field of the IPFIX header) for it to work, but packets do get sent now.