### PR TITLE
Support IPv6

### DIFF
--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -233,13 +233,17 @@ static clib_error_t * ipfix_init (vlib_main_t * vm)
   sm->exporter_ip.data[2] = 1;
   sm->exporter_ip.data[3] = 2;
   sm->observation_domain = 256;
+  sm->idle_flow_timeout = 10 * 1e3;
+  sm->active_flow_timeout = 30 * 1e3;
+  sm->template_timeout = 10 * 1e3;
 
   /* Initialize flow records vector */
   sm->flow_records_ip4 = 0;
   sm->flow_records_ip6 = 0;
 
   /* Initialize expired flow records vector */
-  sm->expired_records = 0;
+  sm->expired_records_ip4 = 0;
+  sm->expired_records_ip6 = 0;
 
   /* Initialize IPFIX data packets vector */
   sm->data_packets = 0;

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -79,6 +79,10 @@ typedef struct {
   u64 active_flow_timeout;
   u64 template_timeout;
 
+  /* allocate templates to use in nodes just once */
+  netflow_v10_template_t * template_ip4;
+  netflow_v10_template_t * template_ip6;
+
   /* vector of expired flows to export */
   ipfix_ip4_flow_value_t * expired_records_ip4;
   ipfix_ip6_flow_value_t * expired_records_ip6;

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -75,9 +75,13 @@ typedef struct {
   u16 exporter_port;
   u16 collector_port;
   u32 observation_domain;
+  u64 idle_flow_timeout;
+  u64 active_flow_timeout;
+  u64 template_timeout;
 
   /* vector of expired flows to export */
-  ipfix_ip4_flow_value_t * expired_records;
+  ipfix_ip4_flow_value_t * expired_records_ip4;
+  ipfix_ip6_flow_value_t * expired_records_ip6;
 
   /* vector of IPFIX data packets to be transmitted */
   netflow_v10_data_packet_t *data_packets;

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -18,6 +18,7 @@
 #include <vnet/vnet.h>
 #include <vnet/ip/ip.h>
 #include <vnet/ethernet/ethernet.h>
+#include <vppinfra/bihash_16_8.h>
 #include <vppinfra/bihash_48_8.h>
 #include <vppinfra/hash.h>
 #include <vppinfra/error.h>
@@ -34,6 +35,14 @@ typedef struct {
 } ipfix_ip4_flow_key_t;
 
 typedef struct {
+  ip6_address_t src;
+  ip6_address_t dst;
+  u8 protocol;
+  u16 src_port;
+  u16 dst_port;
+} ipfix_ip6_flow_key_t;
+
+typedef struct {
   ipfix_ip4_flow_key_t flow_key;
   u64 flow_start; //milliseconds;
   u64 flow_end; // milliseconds;
@@ -42,13 +51,23 @@ typedef struct {
 } ipfix_ip4_flow_value_t;
 
 typedef struct {
+  ipfix_ip4_flow_key_t flow_key;
+  u64 flow_start;
+  u64 flow_end;
+  u64 packet_delta_count;
+  u64 octet_delta_count;
+} ipfix_ip6_flow_value_t;
+
+typedef struct {
   /* API message ID base */
   u16 msg_id_base;
 
-  clib_bihash_48_8_t flow_hash;
+  clib_bihash_16_8_t flow_hash_ip4;
+  clib_bihash_48_8_t flow_hash_ip6;
 
   /* vector of flow records */
-  ipfix_ip4_flow_value_t * flow_records;
+  ipfix_ip4_flow_value_t * flow_records_ip4;
+  ipfix_ip6_flow_value_t * flow_records_ip6;
 
   /* exporter configuration */
   ip4_address_t exporter_ip;

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -51,7 +51,7 @@ typedef struct {
 } ipfix_ip4_flow_value_t;
 
 typedef struct {
-  ipfix_ip4_flow_key_t flow_key;
+  ipfix_ip6_flow_key_t flow_key;
   u64 flow_start;
   u64 flow_end;
   u64 packet_delta_count;

--- a/ipfix/netflow_v10.h
+++ b/ipfix/netflow_v10.h
@@ -6,8 +6,10 @@
 #define protocolIdentifier 4
 #define sourceTransportPort 7
 #define sourceIPv4Address 8
+#define sourceIPv6Address 27
 #define destinationTransportPort 11
 #define destinationIPv4Address 12
+#define destinationIPv6Address 28
 #define flowStartMilliseconds 152
 #define flowEndMilliseconds 153
 
@@ -56,5 +58,6 @@ typedef struct {
 
 typedef struct {
   netflow_v10_header_t header;
+  netflow_v10_template_t *template;
   netflow_v10_data_set_t *sets;
 } netflow_v10_data_packet_t;

--- a/ipfix/node.c
+++ b/ipfix/node.c
@@ -182,33 +182,25 @@ static u8* format_netflow_v10_data_packet(u8 *s, va_list *args) {
 
         switch (field_spec->identifier) {
         case sourceIPv4Address:
-          s = format(s, "\t\t%U", format_ip4_address, (ip4_address_t *)data_set->data);
+        case destinationIPv4Address:
+          s = format(s, "\t\t%U", format_ip4_address, data);
           break;
         case sourceIPv6Address:
         case destinationIPv6Address:
           s = format(s, "\t\t%U", format_ip6_address, data);
           break;
-        case destinationIPv4Address:
-          s = format(s, "\t\t%U", format_ip4_address, data);
-          break;
         case protocolIdentifier:
           s = format(s, "\t\t%u", *(u8 *)data);
           break;
         case sourceTransportPort:
-          s = format(s, "\t\t%U", format_tcp_udp_port, *(u16 *)data);
-          break;
         case destinationTransportPort:
           s = format(s, "\t\t%U", format_tcp_udp_port, *(u16 *)data);
           break;
         case flowStartMilliseconds:
-          s = format(s, "\t\t%U", format_timestamp, clib_byte_swap_u64(*(u64 *)data));
-          break;
         case flowEndMilliseconds:
           s = format(s, "\t\t%U", format_timestamp, clib_byte_swap_u64(*(u64 *)data));
           break;
         case octetDeltaCount:
-          s = format(s, "\t\t%u", clib_byte_swap_u64(*(u64 *)data));
-          break;
         case packetDeltaCount:
           s = format(s, "\t\t%u", clib_byte_swap_u64(*(u64 *)data));
           break;

--- a/setupif.sh
+++ b/setupif.sh
@@ -5,7 +5,8 @@ case "$1" in
          ip link add name vpp1out type veth peer name vpp1host
          ip link set dev vpp1out up
          ip link set dev vpp1host up
-         ip addr add 10.10.1.1/24 dev vpp1host;;
+         ip addr add 10.10.1.1/24 dev vpp1host
+         ip addr add fde4:8dba:82e1::1/64 dev vpp1host;;
      "remove")
          ip link set dev vpp1out down
          ip link set dev vpp1host down

--- a/setupif.vpp
+++ b/setupif.vpp
@@ -1,5 +1,6 @@
 create host-interface name vpp1out
 set int ip address host-vpp1out 10.10.1.2/24
+set int ip address host-vpp1out fde4:8dba:82e1::2/64
 set int state host-vpp1out up
 trace add af-packet-input 30
 ipfix flow-meter host-vpp1out


### PR DESCRIPTION
This PR adds IPv6 support for the metering part of the exporter. Sorry for kind of a large code dump, but a good portion of it is actually duplicated code. The code duplication is unfortunate, but I'm not sure how much of it can be eliminated without being too clever (but would appreciate any ideas on that if you have any).

Part of the problem is that we use different hash sizes because the keys are differently sized. This limits flexibility in kinds of flow keys we can support too, compared to Lua.