### PR TITLE
Add CLI config commands for config parameters

### DIFF
--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -190,6 +190,8 @@ static clib_error_t * ipfix_set_command_fn (vlib_main_t * vm,
                                  "expected port command, got `%U`",
                                  format_unformat_error, input);
       }
+    } else if (unformat(input, "observation-domain %u", &val)) {
+      im->observation_domain = val;
     } else {
       return clib_error_return(0, "unknown command");
     }

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -151,11 +151,11 @@ static clib_error_t * ipfix_set_command_fn (vlib_main_t * vm,
   while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT) {
     if (unformat(input, "timeout")) {
       if (unformat(input, "idle %u", &val)) {
-        im->idle_flow_timeout = val;
+        im->idle_flow_timeout = val * 1e3;
       } else if (unformat(input, "active %u", &val)) {
-        im->active_flow_timeout = val;
+        im->active_flow_timeout = val * 1e3;
       } else if (unformat(input, "template %u", &val)) {
-        im->template_timeout = val;
+        im->template_timeout = val * 1e3;
       } else {
         error = clib_error_return(0,
                                   "expected timeout command, got `%U`",

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -140,14 +140,52 @@ flow_meter_enable_disable_command_fn (vlib_main_t * vm,
   return 0;
 }
 
+static clib_error_t * ipfix_set_command_fn (vlib_main_t * vm,
+                                            unformat_input_t * input,
+                                            vlib_cli_command_t * cmd)
+{
+  clib_error_t *error = 0;
+  u32 val = 0;
+  ipfix_main_t * im = &ipfix_main;
+
+  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT) {
+    if (unformat(input, "timeout")) {
+      if (unformat(input, "idle %u", &val)) {
+        im->idle_flow_timeout = val;
+      } else if (unformat(input, "active %u", &val)) {
+        im->active_flow_timeout = val;
+      } else if (unformat(input, "template %u", &val)) {
+        im->template_timeout = val;
+      } else {
+        error = clib_error_return(0,
+                                  "expected timeout command, got `%U`",
+                                  format_unformat_error, input);
+      }
+    } else {
+      error = clib_error_return(0, "unknown command");
+      break;
+    }
+  }
+
+  return error;
+}
+
 /**
  * @brief CLI command to enable/disable the ipfix plugin.
  */
-VLIB_CLI_COMMAND (sr_content_command, static) = {
-    .path = "ipfix flow-meter",
-    .short_help = 
-    "ipfix flow-meter <interface-name> [disable]",
-    .function = flow_meter_enable_disable_command_fn,
+VLIB_CLI_COMMAND (ipfix_enable_command, static) = {
+  .path = "ipfix flow-meter",
+  .short_help = "ipfix flow-meter <interface-name> [disable]",
+  .function = flow_meter_enable_disable_command_fn,
+};
+
+/**
+ * @brief CLI command to set options for the ipfix plugin.
+ */
+VLIB_CLI_COMMAND (ipfix_set_command, static) = {
+  .path = "set ipfix",
+  .short_help = "set ipfix timeout {idle|active|template} <seconds>",
+  .function = ipfix_set_command_fn,
 };
 
 /**

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -386,16 +386,11 @@ static clib_error_t * ipfix_init (vlib_main_t * vm)
   /* store this node's vlib_main in the ipfix_main_t */
   sm->vlib_main = vm;
 
+  /* Create random port between 49152 to 0xFFFF */
   sm->random_seed = random_default_seed();
+  rand_port = (random_u32(&sm->random_seed) % (0xFFFF - 49152)) + 49152;
 
   /* Initialize configuration values */
-  while (1) {
-    rand_port = random_u32(&sm->random_seed);
-    rand_port &= 0xFFFF;
-    if (rand_port >= 49152) {
-      break;
-    }
-  }
   sm->exporter_port = rand_port;
   sm->collector_port = 4739;
   sm->collector_ip.data[0] = 10;

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -368,9 +368,9 @@ static clib_error_t * ipfix_init (vlib_main_t * vm)
   sm->exporter_ip.data[2] = 1;
   sm->exporter_ip.data[3] = 2;
   sm->observation_domain = 256;
-  sm->idle_flow_timeout = 10 * 1e3;
-  sm->active_flow_timeout = 30 * 1e3;
-  sm->template_timeout = 10 * 1e3;
+  sm->idle_flow_timeout = 300 * 1e3;
+  sm->active_flow_timeout = 120 * 1e3;
+  sm->template_timeout = 600 * 1e3;
 
   /* Initialize templates */
   /* FIXME: do we need to free these at some point? */

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -17,6 +17,7 @@
  * @brief IPFIX Plugin, plugin API / trace / CLI handling.
  */
 
+#include <vnet/ip/ip4_packet.h>
 #include <vnet/vnet.h>
 #include <vnet/plugin/plugin.h>
 #include <ipfix/ipfix.h>
@@ -147,6 +148,7 @@ static clib_error_t * ipfix_set_command_fn (vlib_main_t * vm,
                                             vlib_cli_command_t * cmd)
 {
   u32 val = 0;
+  ip4_address_t addr;
   ipfix_main_t * im = &ipfix_main;
 
   while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT) {
@@ -173,6 +175,16 @@ static clib_error_t * ipfix_set_command_fn (vlib_main_t * vm,
           return clib_error_return(0, "expected valid port");
         }
         im->collector_port = val;
+      } else {
+        return clib_error_return(0,
+                                 "expected port command, got `%U`",
+                                 format_unformat_error, input);
+      }
+    } else if (unformat(input, "ip")) {
+      if (unformat(input, "exporter %U", unformat_ip4_address, &addr)) {
+        im->exporter_ip = addr;
+      } else if (unformat(input, "collector %U", unformat_ip4_address, &addr)) {
+        im->collector_ip = addr;
       } else {
         return clib_error_return(0,
                                  "expected port command, got `%U`",

--- a/ipfix/ipfix.c
+++ b/ipfix/ipfix.c
@@ -214,7 +214,7 @@ VLIB_CLI_COMMAND (ipfix_enable_command, static) = {
  */
 VLIB_CLI_COMMAND (ipfix_set_command, static) = {
   .path = "set ipfix",
-  .short_help = "set ipfix timeout {idle|active|template} <seconds>",
+  .short_help = "set ipfix [timeout {idle|active|template} <seconds>] [{port|ip} {collector|exporter} <value>] [observation-domain <num>]",
   .function = ipfix_set_command_fn,
 };
 

--- a/ipfix/ipfix.h
+++ b/ipfix/ipfix.h
@@ -93,6 +93,8 @@ typedef struct {
   /* track sequence number for IPFIX packets */
   u32 sequence_number;
 
+  u32 random_seed;
+
   /* convenience */
   vlib_main_t * vlib_main;
   vnet_main_t * vnet_main;

--- a/setupif.vpp
+++ b/setupif.vpp
@@ -4,3 +4,4 @@ set int ip address host-vpp1out fde4:8dba:82e1::2/64
 set int state host-vpp1out up
 trace add af-packet-input 30
 ipfix flow-meter host-vpp1out
+set ipfix timeout idle 10 timeout template 10 timeout active 30


### PR DESCRIPTION
Adds commands like `set ipfix timeout active 15` or `set ipfix port collector 4739` and so on.

I'm not sure if it's more idiomatic to have commands like `port collector` or `port-collector`. It's also `port exporter` instead of `exporter port` because the `set ipfix exporter` conflicts with some existing VPP commands.

Use this to set default timeouts to more sensible values and have the test script set them to easily observable values.